### PR TITLE
Fix: RabbitMQ OpenSSL dynamic linking issue

### DIFF
--- a/src/linux_tcp/openssl.cpp
+++ b/src/linux_tcp/openssl.cpp
@@ -45,6 +45,9 @@ namespace OpenSSL {
  */
 bool valid()
 {
+    if (handle == RTLD_DEFAULT)
+        return true;
+
     // create a function
     static Function<decltype(::SSL_CTX_new)> func(handle, "SSL_CTX_new");
 
@@ -58,6 +61,15 @@ bool valid()
  */
 const SSL_METHOD *TLS_client_method()
 {
+    if (handle == RTLD_DEFAULT)
+    {
+        const auto * method = ::TLS_client_method();
+        if (method == nullptr)
+            method = ::SSLv23_client_method();
+
+        return method;
+    }
+
     // create a function that loads the method
     static Function<decltype(TLS_client_method)> func(handle, "TLS_client_method");
 
@@ -78,6 +90,9 @@ const SSL_METHOD *TLS_client_method()
  */
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *method)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_CTX_new(method);
+
     // create a function
     static Function<decltype(::SSL_CTX_new)> func(handle, "SSL_CTX_new");
 
@@ -94,6 +109,9 @@ SSL_CTX *SSL_CTX_new(const SSL_METHOD *method)
  */
 int SSL_read(SSL *ssl, void *buf, int num)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_read(ssl, buf, num);
+
     // create a function
     static Function<decltype(::SSL_read)> func(handle, "SSL_read");
 
@@ -110,6 +128,9 @@ int SSL_read(SSL *ssl, void *buf, int num)
  */
 int SSL_write(SSL *ssl, const void *buf, int num)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_write(ssl, buf, num);
+
     // create a function
     static Function<decltype(::SSL_write)> func(handle, "SSL_write");
 
@@ -125,6 +146,9 @@ int SSL_write(SSL *ssl, const void *buf, int num)
  */
 int SSL_set_fd(SSL *ssl, int fd)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_set_fd(ssl, fd);
+
     // create a function
     static Function<decltype(::SSL_set_fd)> func(handle, "SSL_set_fd");
 
@@ -140,6 +164,9 @@ int SSL_set_fd(SSL *ssl, int fd)
  */
 int SSL_pending(const SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_pending(ssl);
+
     // create a function
     static Function<decltype(::SSL_pending)> func(handle, "SSL_pending");
 
@@ -153,6 +180,9 @@ int SSL_pending(const SSL *ssl)
  */
 void SSL_CTX_free(SSL_CTX *ctx)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_CTX_free(ctx);
+
     // create a function
     static Function<decltype(::SSL_CTX_free)> func(handle, "SSL_CTX_free");
 
@@ -167,6 +197,9 @@ void SSL_CTX_free(SSL_CTX *ctx)
  */
 void SSL_free(SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_free(ssl);
+
     // create a function
     static Function<decltype(::SSL_free)> func(handle, "SSL_free");
 
@@ -181,6 +214,9 @@ void SSL_free(SSL *ssl)
  */
 SSL *SSL_new(SSL_CTX *ctx)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_new(ctx);
+
     // create a function
     static Function<decltype(::SSL_new)> func(handle, "SSL_new");
 
@@ -213,6 +249,9 @@ int SSL_up_ref(SSL *ssl)
  */
 int SSL_shutdown(SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_shutdown(ssl);
+
     // create a function
     static Function<decltype(::SSL_shutdown)> func(handle, "SSL_shutdown");
 
@@ -226,6 +265,9 @@ int SSL_shutdown(SSL *ssl)
  */
 void SSL_set_connect_state(SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_set_connect_state(ssl);
+
     // create a function
     static Function<decltype(::SSL_set_connect_state)> func(handle, "SSL_set_connect_state");
 
@@ -241,6 +283,9 @@ void SSL_set_connect_state(SSL *ssl)
  */
 int SSL_do_handshake(SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_do_handshake(ssl);
+
     // create a function
     static Function<decltype(::SSL_do_handshake)> func(handle, "SSL_do_handshake");
 
@@ -255,6 +300,9 @@ int SSL_do_handshake(SSL *ssl)
  */
 int SSL_get_shutdown(const SSL *ssl)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_get_shutdown(ssl);
+
     // create a function
     static Function<decltype(::SSL_get_shutdown)> func(handle, "SSL_get_shutdown");
 
@@ -270,6 +318,9 @@ int SSL_get_shutdown(const SSL *ssl)
  */
 int SSL_get_error(const SSL *ssl, int ret)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_get_error(ssl, ret);
+
     // create a function
     static Function<decltype(::SSL_get_error)> func(handle, "SSL_get_error");
 
@@ -286,6 +337,9 @@ int SSL_get_error(const SSL *ssl, int ret)
  */
 int SSL_use_certificate_file(SSL *ssl, const char *file, int type)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_use_certificate_file(ssl, file, type);
+
     // create a function
     static Function<decltype(::SSL_use_certificate_file)> func(handle, "SSL_use_certificate_file");
 
@@ -300,6 +354,9 @@ int SSL_use_certificate_file(SSL *ssl, const char *file, int type)
  */
 int SSL_CTX_set_default_verify_paths(SSL_CTX *ctx)
 {
+    if (handle == RTLD_DEFAULT)
+        return ::SSL_CTX_set_default_verify_paths(ctx);
+
     // the actual function
     static Function<decltype(::SSL_CTX_set_default_verify_paths)> func(handle, "SSL_CTX_set_default_verify_paths");
 
@@ -313,6 +370,9 @@ int SSL_CTX_set_default_verify_paths(SSL_CTX *ctx)
  */
 void ERR_clear_error()
 {
+    if (handle == RTLD_DEFAULT)
+        return ::ERR_clear_error();
+
     // create a function
     static Function<decltype(::ERR_clear_error)> func(handle, "ERR_clear_error");
 
@@ -329,6 +389,9 @@ static int SSL_set_tlsext_host_name_impl(SSL *ssl, const char *name)
 
 int SSL_set_tlsext_host_name_func(SSL *ssl, const char *name)
 {
+    if (handle == RTLD_DEFAULT)
+        return SSL_set_tlsext_host_name_impl(ssl, name);
+
     static Function<decltype(SSL_set_tlsext_host_name_impl)> func(handle, "SSL_set_tlsext_host_name");
     return func(ssl, name);
 }
@@ -340,6 +403,9 @@ static uint32_t SSL_CTX_set_mode_impl(SSL_CTX *ctx, uint32_t mode)
 
 uint32_t SSL_CTX_set_mode_func(SSL_CTX *ctx, uint32_t mode)
 {
+    if (handle == RTLD_DEFAULT)
+        return SSL_CTX_set_mode_impl(ctx, mode);
+
     static Function<decltype(SSL_CTX_set_mode_impl)> func(handle, "SSL_CTX_set_mode");
     return func(ctx, mode);
 }
@@ -352,6 +418,12 @@ uint32_t SSL_CTX_set_mode_func(SSL_CTX *ctx, uint32_t mode)
  */
 void ERR_print_errors_cb(int (*cb)(const char *str, size_t len, void *u), void *u)
 {
+    if (handle == RTLD_DEFAULT)
+    {
+        ::ERR_print_errors_cb(cb, u);
+        return;
+    }
+
     // the actual function
     static Function<decltype(::ERR_print_errors_cb)> func(handle, "ERR_print_errors_cb");
 


### PR DESCRIPTION
Broke with https://github.com/ClickHouse/ClickHouse/pull/47475

We now bypass `dlsym` completely (which happens in the ctor of the `Function` wrapper).