### PR TITLE
Fix nullptr dereference in LibUvHandler callback when connection is lost

### DIFF
--- a/include/amqpcpp/libuv.h
+++ b/include/amqpcpp/libuv.h
@@ -63,6 +63,12 @@ private:
             // retrieve the connection
             TcpConnection *connection = static_cast<TcpConnection*>(handle->data);
 
+            // check if the connection is still valid (it might have been destroyed while the event was pending)
+            if (!connection) return;
+
+            // don't process events for a connection that is already closed
+            if (connection->closed()) return;
+
             // tell the connection that its filedescriptor is active
             int fd = -1;
             uv_fileno(reinterpret_cast<uv_handle_t*>(handle), &fd);
@@ -105,6 +111,9 @@ private:
          */
         virtual ~Watcher()
         {
+            // clear the connection pointer so any pending callbacks see nullptr
+            _poll->data = nullptr;
+
             // stop the watcher
             uv_poll_stop(_poll);
 


### PR DESCRIPTION
I just want to close https://github.com/ClickHouse/ClickHouse/issues/84702. I'm not sure about this, but it looks somewhat plausible. Explanation below:

This fixes a crash that occurs when a RabbitMQ connection is lost while the libuv event loop is still processing events. The crash manifests as a segmentation fault in AMQP::TcpConnection::process() with "Address: NULL pointer. Access: read".

Root cause:
-----------
When a RabbitMQ connection is lost or closed, the Watcher object may be destroyed while there are still pending callbacks in libuv's event queue. The callback retrieves the TcpConnection pointer from handle->data and calls connection->process() without any validation. If the Watcher has been destroyed or the connection is in an invalid state, this leads to a nullptr dereference or use-after-free.

The fix adds three layers of protection:

1. Null pointer check in callback: Before calling connection->process(), we now check if the connection pointer is null. This catches the case where the Watcher destructor has already cleared the pointer.

2. Connection closed check in callback: Even if the connection pointer is non-null, we check if the connection is in a closed state via connection->closed(). This prevents processing events on a connection that is shutting down or in an error state.

3. Clear data pointer in Watcher destructor: When the Watcher is destroyed, we set _poll->data = nullptr BEFORE calling uv_poll_stop(). This ensures that any pending callbacks that fire after destruction begins will see the null pointer and return early.

Thread safety considerations:
-----------------------------
This fix relies on libuv's single-threaded event loop model where all handle operations (callbacks, uv_poll_stop, uv_close) must happen on the same thread that runs uv_run(). In this model:

- The callback and Watcher destructor are serialized by the event loop
- The destructor is called from monitor() -> _watchers.erase(), which happens during connection->process(), which happens during a callback, which happens during uv_run()
- Setting _poll->data = nullptr before uv_poll_stop() ensures any subsequent callback iteration sees the null pointer

ClickHouse's RabbitMQHandler adds additional synchronization via startup_mutex which serializes access to uv_run(), providing an extra layer of protection for scenarios where multiple threads interact with the event loop.

Fixes: ClickHouse/ClickHouse#84702